### PR TITLE
Few changes and refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 # Go workspace file
 go.work
+.idea
+/.idea

--- a/fastotp.go
+++ b/fastotp.go
@@ -10,6 +10,10 @@ import (
 	"github.com/CeoFred/fast-otp/lib"
 )
 
+const (
+	BaseUrl = "https://api.fastotp.co"
+)
+
 type FastOtp struct {
 	APIKey  *string
 	BaseURL string
@@ -38,18 +42,18 @@ type DeliveryDetails struct {
 	Email string `json:"email"`
 }
 
+type OtpDelivery map[string]string
+
 type GenerateOTPPayload struct {
-	Delivery struct {
-		Email string `json:"email"`
-	} `json:"delivery"`
-	Identifier  string `json:"identifier"`
-	TokenLength int    `json:"token_length"`
-	Type        string `json:"type"`
-	Validity    int    `json:"validity"`
+	Delivery    OtpDelivery `json:"delivery"`
+	Identifier  string      `json:"identifier"`
+	TokenLength int         `json:"token_length"`
+	Type        string      `json:"type"`
+	Validity    int         `json:"validity"`
 }
 
 func NewFastOTP(apiKey string) *FastOtp {
-	return &FastOtp{APIKey: &apiKey, BaseURL: "https://api.fastotp.co"}
+	return &FastOtp{APIKey: &apiKey, BaseURL: BaseUrl}
 }
 
 func (f *FastOtp) GenerateOTP(payload GenerateOTPPayload) (*OTP, error) {

--- a/fastotp_test.go
+++ b/fastotp_test.go
@@ -45,12 +45,12 @@ func TestGenerateOTP(t *testing.T) {
 
 	fastOtp := &FastOtp{APIKey: new(string), BaseURL: server.URL}
 
+	delivery := OtpDelivery{
+		"email": "test@example.com",
+	}
+
 	payload := GenerateOTPPayload{
-		Delivery: struct {
-			Email string `json:"email"`
-		}{
-			Email: "test@example.com",
-		},
+		Delivery:    delivery,
 		Identifier:  "test_identifier",
 		TokenLength: 6,
 		Type:        "alpha_numeric",

--- a/lib/http.go
+++ b/lib/http.go
@@ -3,6 +3,7 @@ package httpclient
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
@@ -20,7 +21,6 @@ func NewAPIClient(baseURL, apiKey string) *APIClient {
 	}
 }
 
-
 // Post sends a POST request to the specified endpoint with the given payload.
 func (c *APIClient) Post(endpoint string, payload interface{}) (*http.Response, error) {
 	url := c.BaseURL + endpoint
@@ -31,13 +31,13 @@ func (c *APIClient) Post(endpoint string, payload interface{}) (*http.Response, 
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payloadBytes))
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payloadBytes))
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.APIKey))
 
 	client := http.DefaultClient
 	return client.Do(req)


### PR DESCRIPTION
- Replaced "POST" with http.MethodPost. This is minor change 😆
- Moved Base url to a constant for future development
- Added OtpDelivery type for ease of development

I was not able to add more feature since fast-otp requires credit card to have api key