### PR TITLE
add ctx propagation on all lib functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ func main() {
 	// Create an instance of FastOtp
 	client := fastotp.NewFastOTP(apiKey)
 
+	// Create context for library functions
+	ctx := context.Background()
+
 	// Define OTP generation payload
 	payload := fastotp.GenerateOTPPayload{
     Delivery: OtpDelivery{
@@ -42,7 +45,7 @@ func main() {
 	}
 
 	// Generate OTP
-	otp, err := client.GenerateOTP(payload)
+	otp, err := client.GenerateOTP(ctx, payload)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -51,9 +54,10 @@ func main() {
 
   // Validate OTP
   otp, err = client.ValidateOTP(
+	 ctx,
      ValidateOTPPayload{
         Identifier: "user123",
-        Token: "123456"
+        Token: "123456",
     }
   )
 	if err != nil {

--- a/fastotp.go
+++ b/fastotp.go
@@ -1,6 +1,7 @@
 package fastotp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -62,8 +63,8 @@ func NewFastOTP(apiKey string) *FastOtp {
 	return &FastOtp{APIKey: &apiKey, BaseURL: BaseURL}
 }
 
-func (f *FastOtp) GenerateOTP(payload GenerateOTPPayload) (*OTP, error) {
-	cl := httpclient.NewAPIClient(f.BaseURL, *f.APIKey)
+func (f *FastOtp) GenerateOTP(ctx context.Context, payload GenerateOTPPayload) (*OTP, error) {
+	cl := httpclient.NewAPIClient(f.BaseURL, *f.APIKey, ctx)
 	resp, err := cl.Post("/generate", payload)
 	if err != nil {
 		return nil, err
@@ -91,8 +92,8 @@ func (f *FastOtp) GenerateOTP(payload GenerateOTPPayload) (*OTP, error) {
 	return &otpResponse.OTP, nil
 }
 
-func (f *FastOtp) ValidateOTP(payload ValidateOTPPayload) (*OTP, error) {
-	cl := httpclient.NewAPIClient(f.BaseURL, *f.APIKey)
+func (f *FastOtp) ValidateOTP(ctx context.Context, payload ValidateOTPPayload) (*OTP, error) {
+	cl := httpclient.NewAPIClient(f.BaseURL, *f.APIKey, ctx)
 	resp, err := cl.Post("/validate", payload)
 	if err != nil {
 		return nil, err
@@ -120,8 +121,8 @@ func (f *FastOtp) ValidateOTP(payload ValidateOTPPayload) (*OTP, error) {
 	return &otpResponse.OTP, nil
 }
 
-func (f *FastOtp) GetOtp(id string) (*OTP, error) {
-	cl := httpclient.NewAPIClient(f.BaseURL, *f.APIKey)
+func (f *FastOtp) GetOtp(ctx context.Context, id string) (*OTP, error) {
+	cl := httpclient.NewAPIClient(f.BaseURL, *f.APIKey, ctx)
 	resp, err := cl.Get(id)
 	if err != nil {
 		fmt.Println("got here")

--- a/fastotp_test.go
+++ b/fastotp_test.go
@@ -1,6 +1,7 @@
 package fastotp
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,7 +56,8 @@ func TestGenerateOTP(t *testing.T) {
 		Validity:    120,
 	}
 
-	otp, err := fastOtp.GenerateOTP(payload)
+	ctx := context.Background()
+	otp, err := fastOtp.GenerateOTP(ctx, payload)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -109,7 +111,8 @@ func TestValidateOTP(t *testing.T) {
 		Token:      "123456",
 	}
 
-	otp, err := fastOtp.ValidateOTP(payload)
+	ctx := context.Background()
+	otp, err := fastOtp.ValidateOTP(ctx, payload)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/CeoFred/fast-otp
 
-go 1.21.2
+go 1.23

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/CeoFred/fast-otp
 
-go 1.23
+go 1.21.2

--- a/lib/http.go
+++ b/lib/http.go
@@ -2,6 +2,7 @@ package httpclient
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -11,13 +12,15 @@ import (
 type APIClient struct {
 	BaseURL string
 	APIKey  string
+	Ctx     context.Context
 }
 
 // NewAPIClient creates a new instance of APIClient.
-func NewAPIClient(baseURL, apiKey string) *APIClient {
+func NewAPIClient(baseURL, apiKey string, ctx context.Context) *APIClient {
 	return &APIClient{
 		BaseURL: baseURL,
 		APIKey:  apiKey,
+		Ctx:     ctx,
 	}
 }
 
@@ -31,7 +34,7 @@ func (c *APIClient) Post(endpoint string, payload interface{}) (*http.Response, 
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payloadBytes))
+	req, err := http.NewRequestWithContext(c.Ctx, http.MethodPost, url, bytes.NewBuffer(payloadBytes))
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +51,7 @@ func (c *APIClient) Get(id string) (*http.Response, error) {
 	url := fmt.Sprintf("%s/%s", c.BaseURL, id)
 	fmt.Println(url)
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(c.Ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/http.go
+++ b/lib/http.go
@@ -10,23 +10,23 @@ import (
 
 // APIClient is a wrapper for making HTTP requests to the fastotp API.
 type APIClient struct {
-	BaseURL string
-	APIKey  string
-	Ctx     context.Context
+	baseURL string
+	apiKey  string
+	ctx     context.Context
 }
 
 // NewAPIClient creates a new instance of APIClient.
 func NewAPIClient(baseURL, apiKey string, ctx context.Context) *APIClient {
 	return &APIClient{
-		BaseURL: baseURL,
-		APIKey:  apiKey,
-		Ctx:     ctx,
+		baseURL: baseURL,
+		apiKey:  apiKey,
+		ctx:     ctx,
 	}
 }
 
 // Post sends a POST request to the specified endpoint with the given payload.
 func (c *APIClient) Post(endpoint string, payload interface{}) (*http.Response, error) {
-	url := c.BaseURL + endpoint
+	url := c.baseURL + endpoint
 
 	// Convert payload to JSON
 	payloadBytes, err := json.Marshal(payload)
@@ -34,13 +34,13 @@ func (c *APIClient) Post(endpoint string, payload interface{}) (*http.Response, 
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(c.Ctx, http.MethodPost, url, bytes.NewBuffer(payloadBytes))
+	req, err := http.NewRequestWithContext(c.ctx, http.MethodPost, url, bytes.NewBuffer(payloadBytes))
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", c.APIKey)
+	req.Header.Set("x-api-key", c.apiKey)
 
 	client := http.DefaultClient
 	return client.Do(req)
@@ -48,16 +48,16 @@ func (c *APIClient) Post(endpoint string, payload interface{}) (*http.Response, 
 
 // Get sends a GET request to the specified endpoint, appending id as a path parameter
 func (c *APIClient) Get(id string) (*http.Response, error) {
-	url := fmt.Sprintf("%s/%s", c.BaseURL, id)
+	url := fmt.Sprintf("%s/%s", c.baseURL, id)
 	fmt.Println(url)
 
-	req, err := http.NewRequestWithContext(c.Ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(c.ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", c.APIKey)
+	req.Header.Set("x-api-key", c.apiKey)
 
 	client := http.DefaultClient
 	return client.Do(req)


### PR DESCRIPTION
Enhancing the lib functions to include context for increased user controls would be valuable. This would give the end developer utilizing this library more control from within their applications.

```
payload := fastotp.GenerateOTPPayload{
    Delivery: OtpDelivery{
      "email": "example@example.com",
    },
		Identifier:  "user123",
		TokenLength: 6,
		Type:        "numeric",
		Validity:    120,
	}

// Generate OTP
otp, err := client.GenerateOTP(ctx, payload)
// ... I can cancel or set timeout based on my business rules
```